### PR TITLE
Added best_fit method to Sphere.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Marcelo Moreno [https://github.com/martxelo]

--- a/skspatial/objects/sphere.py
+++ b/skspatial/objects/sphere.py
@@ -314,3 +314,62 @@ class Sphere(_BaseSphere):
         X, Y, Z = self.to_mesh(n_angles)
 
         ax_3d.plot_surface(X, Y, Z, **kwargs)
+
+    @classmethod
+    def best_fit(cls, points: array_like) -> 'Sphere':
+        """
+        Return the sphere of best fit for a set of 3D points.
+
+        Parameters
+        ----------
+        points : array_like
+             Input 3D points.
+
+        Returns
+        -------
+        Sphere
+            The sphere of best fit.
+
+        Raises
+        ------
+        ValueError
+            If the points are in a plane, or are not 3D or are fewer than four.
+
+        Examples
+        --------
+        >>> from skspatial.objects import Sphere
+
+        >>> points = [[1, 0, 1], [0, 1, 1], [1, 2, 1], [1, 1, 2]]
+        >>> sphere = Sphere.best_fit(points)
+
+        The point in the sphere is the center.
+
+        >>> sphere.point.round(3)
+        Point([1., 1., 1.])
+
+        The radius of the sphere is calculated.
+
+        >>> np.round(sphere.radius, 3)
+        1.0
+        """
+        points = Points(points)
+
+        if points.dimension != 3:
+            raise ValueError("The points must be 3D.")
+
+        if points.shape[0] < 4:
+            raise ValueError("There must be at least 4 points.")
+
+        if points.affine_rank() != 3:
+            raise ValueError("The points must not be in a plane.")
+
+        n = points.shape[0]
+        A = np.hstack((2 * points, np.ones((n, 1))))
+        b = (points ** 2).sum(axis=1)
+
+        c, residues, rank, s = np.linalg.lstsq(A, b, rcond=None)
+
+        center = c[:3]
+        radius = float(np.sqrt(np.dot(center, center) + c[3]))
+
+        return cls(center, radius)

--- a/skspatial/tests/unit/test_fitting.py
+++ b/skspatial/tests/unit/test_fitting.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 import pytest
 
-from skspatial.objects import Line, Plane, Points
+from skspatial.objects import Line, Plane, Points, Sphere
 
 
 @pytest.mark.parametrize(
@@ -145,3 +145,34 @@ def test_best_fit_plane_failure(points, message_expected):
 
     with pytest.raises(ValueError, match=message_expected):
         Plane.best_fit(points)
+
+
+@pytest.mark.parametrize(
+    "points, sphere_expected",
+    [
+        ([[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, 0, 1]], Sphere(point=[0, 0, 0], radius=1)),
+        ([[2, 0, 0], [-2, 0, 0], [0, 2, 0], [0, 0, 2]], Sphere(point=[0, 0, 0], radius=2)),
+        ([[1, 0, 1], [0, 1, 1], [1, 2, 1], [1, 1, 2]], Sphere(point=[1, 1, 1], radius=1)),
+    ],
+)
+def test_best_fit_sphere(points, sphere_expected):
+
+    points = Points(points)
+    sphere_fit = Sphere.best_fit(points)
+
+    assert np.allclose(sphere_fit.point, sphere_expected.point)
+    assert np.isclose(sphere_fit.radius, sphere_expected.radius)
+
+
+@pytest.mark.parametrize(
+    "points, message_expected",
+    [
+        ([[1, 0], [-1, 0], [0, 1], [0, 0]], "The points must be 3D."),
+        ([[2, 0, 0], [-2, 0, 0], [0, 2, 0]], "There must be at least 4 points."),
+        ([[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0]], "The points must not be in a plane."),
+    ],
+)
+def test_best_fit_sphere_failure(points, message_expected):
+
+    with pytest.raises(ValueError, match=message_expected):
+        Sphere.best_fit(points)


### PR DESCRIPTION
Hello @ajhynes7 

I have created a method for fitting a set of points to a sphere with a least squares solver. It follows the same structure as Plane.best_fit(). The docstring also follows the structure of the Plane.best_fit() docstring.

The method checks if the dimension of the points is equal to 3, checks that there are at least 4 points and that the points do not lie on a plane. Calculates the center and the radius of the sphere that minimizes the distance between the points and the sphere.

I have not updated the tests because there is not a test for Plane.best_fit() method.

I have also updated gitignore for ignoring the virtual environment and PyCharm project folderm but maybe you prefer to remove that.

I hope you like it.

Martxelo