### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 install: pip install codecov
 script: 
-  - bash ci/scripts/run_stages.sh $stage $TRAVIS_PYTHON_VERSION
+  - bash ci/scripts/run_stages.sh $TRAVIS_PYTHON_VERSION
 after_success:
     - codecov
 deploy:


### PR DESCRIPTION
Hi @ajhynes7 I was trying to get the tests up and running and, I'm not really sure, but I guess this `$stage` parameter is unneeded here, as `run_stages.sh` doesn't read this. It's probably working because it's an empty string but maybe it's more clear with the fix, specially because it's the _how-to-test_ documentation.

Best regards!