### PR TITLE
Remove `xfail` from tests

### DIFF
--- a/tests/unit/objects/test_plane.py
+++ b/tests/unit/objects/test_plane.py
@@ -260,7 +260,7 @@ def test_sum_squares_plane(plane, points, error_expected):
             [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]],
             Plane([0.25, 0.25, 0.25], [1, 1, 1]),
         ),
-        pytest.param(
+        (
             [
                 [0, 0, 0],
                 [0, 0, 1],
@@ -272,7 +272,6 @@ def test_sum_squares_plane(plane, points, error_expected):
                 [1, 1, 1],
             ],
             Plane([0.5, 0.5, 0.5], [0, 1, 0]),
-            marks=pytest.mark.xfail(reason="Fails on Travis CI for unknown reason."),
         ),
     ],
 )
@@ -290,15 +289,13 @@ def test_best_fit(points, plane_expected):
     [
         ([[0, 0], [1, 0]], "The points must be 3D."),
         ([[0, 0], [2, 5]], "The points must be 3D."),
-        pytest.param(
+        (
             [[0, 0, 0], [1, 1, 1], [2, 2, 2]],
             "The points must not be collinear.",
-            marks=pytest.mark.xfail(reason="Fails on Travis CI for unknown reason."),
         ),
-        pytest.param(
+        (
             [[0, 0, 0], [1, 1, 1], [-10, -10, -10]],
             "The points must not be collinear.",
-            marks=pytest.mark.xfail(reason="Fails on Travis CI for unknown reason."),
         ),
     ],
 )


### PR DESCRIPTION
These tests used to fail on the CI server.