### PR TITLE
Feat: Add method `Vector.angle_signed_3d`

### DIFF
--- a/docs/source/api_reference/skspatial.objects.Vector.rst
+++ b/docs/source/api_reference/skspatial.objects.Vector.rst
@@ -12,7 +12,6 @@ Methods
 
    ~skspatial.objects.Vector.angle_between
    ~skspatial.objects.Vector.angle_signed
-   ~skspatial.objects.Vector.angle_signed_3d
    ~skspatial.objects.Vector.cosine_similarity
    ~skspatial.objects.Vector.cross
    ~skspatial.objects.Vector.different_direction

--- a/docs/source/api_reference/skspatial.objects.Vector.rst
+++ b/docs/source/api_reference/skspatial.objects.Vector.rst
@@ -12,6 +12,7 @@ Methods
 
    ~skspatial.objects.Vector.angle_between
    ~skspatial.objects.Vector.angle_signed
+   ~skspatial.objects.Vector.angle_signed_3d
    ~skspatial.objects.Vector.cosine_similarity
    ~skspatial.objects.Vector.cross
    ~skspatial.objects.Vector.different_direction

--- a/src/skspatial/_functions.py
+++ b/src/skspatial/_functions.py
@@ -61,11 +61,12 @@ def np_float(func: Callable) -> Callable[..., np.float64]:
     Outputs with type np.float64 have a useful round() method.
 
     """
+
     # wraps() is needed so that sphinx generates
     # the docstring of functions with this decorator.
     @wraps(func)
-    def wrapper(*args):
-        return np.float64(func(*args))
+    def wrapper(*args, **kwargs):
+        return np.float64(func(*args, **kwargs))
 
     return wrapper
 
@@ -122,7 +123,7 @@ def _solve_quadratic(a: float, b: float, c: float, n_digits: Optional[int] = Non
     if a == 0:
         raise ValueError("The coefficient `a` must be non-zero.")
 
-    discriminant = b**2 - 4 * a * c
+    discriminant = b ** 2 - 4 * a * c
 
     if discriminant < 0:
         raise ValueError("The discriminant must not be negative.")

--- a/src/skspatial/_functions.py
+++ b/src/skspatial/_functions.py
@@ -61,7 +61,6 @@ def np_float(func: Callable) -> Callable[..., np.float64]:
     Outputs with type np.float64 have a useful round() method.
 
     """
-
     # wraps() is needed so that sphinx generates
     # the docstring of functions with this decorator.
     @wraps(func)
@@ -123,7 +122,7 @@ def _solve_quadratic(a: float, b: float, c: float, n_digits: Optional[int] = Non
     if a == 0:
         raise ValueError("The coefficient `a` must be non-zero.")
 
-    discriminant = b ** 2 - 4 * a * c
+    discriminant = b**2 - 4 * a * c
 
     if discriminant < 0:
         raise ValueError("The discriminant must not be negative.")

--- a/src/skspatial/_functions.py
+++ b/src/skspatial/_functions.py
@@ -61,12 +61,11 @@ def np_float(func: Callable) -> Callable[..., np.float64]:
     Outputs with type np.float64 have a useful round() method.
 
     """
-
     # wraps() is needed so that sphinx generates
     # the docstring of functions with this decorator.
     @wraps(func)
-    def wrapper(*args, **kwargs):
-        return np.float64(func(*args, **kwargs))
+    def wrapper(*args):
+        return np.float64(func(*args))
 
     return wrapper
 
@@ -123,7 +122,7 @@ def _solve_quadratic(a: float, b: float, c: float, n_digits: Optional[int] = Non
     if a == 0:
         raise ValueError("The coefficient `a` must be non-zero.")
 
-    discriminant = b ** 2 - 4 * a * c
+    discriminant = b**2 - 4 * a * c
 
     if discriminant < 0:
         raise ValueError("The discriminant must not be negative.")

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -458,7 +458,7 @@ class Vector(_BaseArray1D):
             raise ValueError("The vectors must be 3D.")
 
         cross = self.cross(other)
-        if not Vector(cross).is_parallel(direction_positive):
+        if not cross.is_parallel(direction_positive):
             raise ValueError(
                 "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
             )

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -417,7 +417,7 @@ class Vector(_BaseArray1D):
         ------
         ValueError
             If the vectors are not 3D.
-            If the positive direction vector is not perpendicular to the plane formed by the two input vectors.
+            If the positive direction vector is not perpendicular to the plane formed by the two main input vectors.
 
         References
         ----------
@@ -451,7 +451,7 @@ class Vector(_BaseArray1D):
         >>> Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], [0, 2, 0])
         Traceback (most recent call last):
         ...
-        ValueError: The positive direction vector must be perpendicular to the plane formed by the two input vectors.
+        ValueError: The positive direction vector must be perpendicular to the plane formed by the two main input vectors.
 
         """
         if not all([self.dimension == 3, Vector(other).dimension == 3, Vector(direction_positive).dimension == 3]):

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -395,7 +395,7 @@ class Vector(_BaseArray1D):
         return math.atan2(det, dot)
 
     @np_float
-    def angle_signed_3d(self, other: array_like, positive_direction: array_like) -> float:
+    def angle_signed_3d(self, other: array_like, direction_positive: array_like) -> float:
         """
         Return the signed angle in radians between the vector and another.
 
@@ -405,7 +405,7 @@ class Vector(_BaseArray1D):
         ----------
         other : array_like
             Other vector.
-        positive_direction : array_like
+        direction_positive : array_like
             Vector perpendicular to the plane formed by the two input vectors.
 
         Returns
@@ -432,10 +432,10 @@ class Vector(_BaseArray1D):
         >>> import numpy as np
         >>> from skspatial.objects import Vector
 
-        >>> np.degrees(Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], positive_direction=[0, 0, 2]))
+        >>> np.degrees(Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], direction_positive=[0, 0, 2]))
         -90.0
 
-        >>> np.degrees(Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], positive_direction=[0, 0, -5]))
+        >>> np.degrees(Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], direction_positive=[0, 0, -5]))
         90.0
 
         >>> Vector([1, 0]).angle_signed_3d([1, 0], [1, 0, 0])
@@ -454,16 +454,16 @@ class Vector(_BaseArray1D):
         ValueError: The positive direction vector must be perpendicular to the plane formed by the two input vectors.
 
         """
-        if not all([self.dimension == 3, Vector(other).dimension == 3, Vector(positive_direction).dimension == 3]):
+        if not all([self.dimension == 3, Vector(other).dimension == 3, Vector(direction_positive).dimension == 3]):
             raise ValueError("The vectors must be 3D.")
 
         cross = self.cross(other)
-        if not Vector(cross).is_parallel(positive_direction):
+        if not Vector(cross).is_parallel(direction_positive):
             raise ValueError(
                 "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
             )
-        positive_direction = Vector(positive_direction).unit()
-        return np.arctan2(cross.dot(positive_direction), self.dot(other))
+        direction_positive = Vector(direction_positive).unit()
+        return np.arctan2(cross.dot(direction_positive), self.dot(other))
 
     def is_perpendicular(self, other: array_like, **kwargs: float) -> bool:
         r"""

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -461,9 +461,9 @@ class Vector(_BaseArray1D):
 
         if not cross.is_parallel(direction_positive):
             raise ValueError(
-                "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
+                "The positive direction vector must be perpendicular to the plane formed by the two main input vectors."
             )
-        
+
         direction_positive = Vector(direction_positive).unit()
         return np.arctan2(cross.dot(direction_positive), self.dot(other))
 

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -451,7 +451,8 @@ class Vector(_BaseArray1D):
         >>> Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], [0, 2, 0])
         Traceback (most recent call last):
         ...
-        ValueError: The positive direction vector must be perpendicular to the plane formed by the two main input vectors.
+        ValueError: The positive direction vector must be perpendicular to the plane formed by the two main input ...
+        vectors.
 
         """
         if not all([self.dimension == 3, Vector(other).dimension == 3, Vector(direction_positive).dimension == 3]):
@@ -461,7 +462,10 @@ class Vector(_BaseArray1D):
 
         if not cross.is_parallel(direction_positive):
             raise ValueError(
-                "The positive direction vector must be perpendicular to the plane formed by the two main input vectors."
+                (
+                    "The positive direction vector must be perpendicular to the plane formed by the two main input "
+                    "vectors."
+                ),
             )
 
         direction_positive = Vector(direction_positive).unit()

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import math
-from typing import cast, Optional
+from typing import cast
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -345,16 +345,16 @@ class Vector(_BaseArray1D):
         return math.acos(cos_theta)
 
     @np_float
-    def angle_signed(self, other: array_like, positive_direction: Optional[array_like] = None) -> float:
+    def angle_signed(self, other: array_like) -> float:
         """
         Return the signed angle in radians between the vector and another.
+
+        The vectors must be 2D.
 
         Parameters
         ----------
         other : array_like
             Other vector.
-        positive_direction : array_like, optional
-            Vector perpendicular to the plane formed by the two input vectors (default None).
 
         Returns
         -------
@@ -364,7 +364,7 @@ class Vector(_BaseArray1D):
         Raises
         ------
         ValueError
-            If the positive direction vector is not perpendicular to the plane formed by the two input vectors.
+            If the vectors are not 2D.
 
         Examples
         --------
@@ -380,34 +380,19 @@ class Vector(_BaseArray1D):
         >>> np.degrees(Vector([1, 0]).angle_signed([0, -1]))
         -90.0
 
-        >>> np.degrees(Vector([1, 0, 0]).angle_signed([0, -1, 0]))
-        90.0
-
-        >>> np.degrees(Vector([1, 0, 0]).angle_signed([0, -1, 0], positive_direction=[0, 0, 2]))
-        -90.0
-
-        >>> Vector([1, 0, 0]).angle_signed([0, -1, 0], positive_direction=[0, 2, 0])
+        >>> Vector([1, 0, 0]).angle_signed([0, -1, 0])
         Traceback (most recent call last):
         ...
-        ValueError: The positive direction vector must be perpendicular to the plane formed by the two input vectors.
+        ValueError: The vectors must be 2D.
 
         """
-        if self.dimension == 2:
-            dot = self.dot(other)
-            det = np.linalg.det([self, other])
-            return math.atan2(det, dot)
+        if not (self.dimension == 2 and Vector(other).dimension == 2):
+            raise ValueError("The vectors must be 2D.")
 
-        if positive_direction is None:
-            return self.angle_between(other)
+        dot = self.dot(other)
+        det = np.linalg.det([self, other])
 
-        cross = self.cross(other)
-        if not Vector(cross).is_parallel(positive_direction):
-            raise ValueError(
-                "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
-            )
-
-        similarity = Vector(cross).cosine_similarity(positive_direction)
-        return self.angle_between(other) * similarity
+        return math.atan2(det, dot)
 
     def is_perpendicular(self, other: array_like, **kwargs: float) -> bool:
         r"""

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import math
-from typing import cast
+from typing import cast, Optional
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -345,16 +345,16 @@ class Vector(_BaseArray1D):
         return math.acos(cos_theta)
 
     @np_float
-    def angle_signed(self, other: array_like) -> float:
+    def angle_signed(self, other: array_like, positive_direction: Optional[array_like] = None) -> float:
         """
         Return the signed angle in radians between the vector and another.
-
-        The vectors must be 2D.
 
         Parameters
         ----------
         other : array_like
             Other vector.
+        positive_direction : array_like, optional
+            Vector perpendicular to the plane formed by the two input vectors (default None).
 
         Returns
         -------
@@ -364,7 +364,7 @@ class Vector(_BaseArray1D):
         Raises
         ------
         ValueError
-            If the vectors are not 2D.
+            If the positive direction vector is not perpendicular to the plane formed by the two input vectors.
 
         Examples
         --------
@@ -380,19 +380,34 @@ class Vector(_BaseArray1D):
         >>> np.degrees(Vector([1, 0]).angle_signed([0, -1]))
         -90.0
 
-        >>> Vector([1, 0, 0]).angle_signed([0, -1, 0])
+        >>> np.degrees(Vector([1, 0, 0]).angle_signed([0, -1, 0]))
+        90.0
+
+        >>> np.degrees(Vector([1, 0, 0]).angle_signed([0, -1, 0], positive_direction=[0, 0, 2]))
+        -90.0
+
+        >>> Vector([1, 0, 0]).angle_signed([0, -1, 0], positive_direction=[0, 2, 0])
         Traceback (most recent call last):
         ...
-        ValueError: The vectors must be 2D.
+        ValueError: The positive direction vector must be perpendicular to the plane formed by the two input vectors.
 
         """
-        if not (self.dimension == 2 and Vector(other).dimension == 2):
-            raise ValueError("The vectors must be 2D.")
+        if self.dimension == 2:
+            dot = self.dot(other)
+            det = np.linalg.det([self, other])
+            return math.atan2(det, dot)
 
-        dot = self.dot(other)
-        det = np.linalg.det([self, other])
+        if positive_direction is None:
+            return self.angle_between(other)
 
-        return math.atan2(det, dot)
+        cross = self.cross(other)
+        if not Vector(cross).is_parallel(positive_direction):
+            raise ValueError(
+                "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
+            )
+
+        similarity = Vector(cross).cosine_similarity(positive_direction)
+        return self.angle_between(other) * similarity
 
     def is_perpendicular(self, other: array_like, **kwargs: float) -> bool:
         r"""

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -394,6 +394,77 @@ class Vector(_BaseArray1D):
 
         return math.atan2(det, dot)
 
+    @np_float
+    def angle_signed_3d(self, other: array_like, positive_direction: array_like) -> float:
+        """
+        Return the signed angle in radians between the vector and another.
+
+        The vectors must be 3D.
+
+        Parameters
+        ----------
+        other : array_like
+            Other vector.
+        positive_direction : array_like
+            Vector perpendicular to the plane formed by the two input vectors.
+
+        Returns
+        -------
+        np.float64
+            Signed angle between vectors in radians.
+
+        Raises
+        ------
+        ValueError
+            If the vectors are not 3D.
+            If the positive direction vector is not perpendicular to the plane formed by the two input vectors.
+
+        References
+        ----------
+        https://stackoverflow.com/questions/5188561/signed-angle-between-two-3d-vectors-with-same-origin-within-the-same-plane
+
+        Notes
+        -----
+        Right-handed rotation.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from skspatial.objects import Vector
+
+        >>> np.degrees(Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], positive_direction=[0, 0, 2]))
+        -90.0
+
+        >>> np.degrees(Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], positive_direction=[0, 0, -5]))
+        90.0
+
+        >>> Vector([1, 0]).angle_signed_3d([1, 0], [1, 0, 0])
+        Traceback (most recent call last):
+        ...
+        ValueError: The vectors must be 3D.
+
+        >>> Vector([1, 0, 4]).angle_signed_3d([1, 0, 5], [1, 0])
+        Traceback (most recent call last):
+        ...
+        ValueError: The vectors must be 3D.
+
+        >>> Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], [0, 2, 0])
+        Traceback (most recent call last):
+        ...
+        ValueError: The positive direction vector must be perpendicular to the plane formed by the two input vectors.
+
+        """
+        if not all([self.dimension == 3, Vector(other).dimension == 3, Vector(positive_direction).dimension == 3]):
+            raise ValueError("The vectors must be 3D.")
+
+        cross = self.cross(other)
+        if not Vector(cross).is_parallel(positive_direction):
+            raise ValueError(
+                "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
+            )
+        positive_direction = Vector(positive_direction).unit()
+        return np.arctan2(cross.dot(positive_direction), self.dot(other))
+
     def is_perpendicular(self, other: array_like, **kwargs: float) -> bool:
         r"""
         Check if the vector is perpendicular to another.

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -404,9 +404,9 @@ class Vector(_BaseArray1D):
         Parameters
         ----------
         other : array_like
-            Other vector.
+            Other main input vector.
         direction_positive : array_like
-            Vector perpendicular to the plane formed by the two input vectors.
+            A vector perpendicular to the plane formed by the two main input vectors.
 
         Returns
         -------
@@ -425,7 +425,7 @@ class Vector(_BaseArray1D):
 
         Notes
         -----
-        Right-handed rotation.
+        This method uses the convention of right-handed rotation.
 
         Examples
         --------

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -448,12 +448,6 @@ class Vector(_BaseArray1D):
         ...
         ValueError: The vectors must be 3D.
 
-        >>> Vector([1, 0, 0]).angle_signed_3d([0, -1, 0], [0, 2, 0])
-        Traceback (most recent call last):
-        ...
-        ValueError: The positive direction vector must be perpendicular to the plane formed by the two main input ...
-        vectors.
-
         """
         if not all([self.dimension == 3, Vector(other).dimension == 3, Vector(direction_positive).dimension == 3]):
             raise ValueError("The vectors must be 3D.")

--- a/src/skspatial/objects/vector.py
+++ b/src/skspatial/objects/vector.py
@@ -458,10 +458,12 @@ class Vector(_BaseArray1D):
             raise ValueError("The vectors must be 3D.")
 
         cross = self.cross(other)
+
         if not cross.is_parallel(direction_positive):
             raise ValueError(
                 "The positive direction vector must be perpendicular to the plane formed by the two input vectors."
             )
+        
         direction_positive = Vector(direction_positive).unit()
         return np.arctan2(cross.dot(direction_positive), self.dot(other))
 

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -141,6 +141,39 @@ def test_angle_signed(array_u, array_v, angle_expected):
         angle = Vector(array_u).angle_signed(array_v)
         assert math.isclose(angle, angle_expected)
 
+@pytest.mark.parametrize(
+    ("array_u", "array_v", "positive_direction", "angle_expected"),
+    [
+        ([1, 0], [1, 0], [0, 0, 3], None),
+        ([3, 0, 0], [0, 2, 0], [0, 1, 1], None),
+        ([2, -1, 0], [0, 2, 0], [1, 1], None),
+        ([1, 0, 0], [1, 0, 0], [1, 2, 3], 0),
+        ([1, 0, 0], [-1, 0, 0], [1, 2, 3], np.pi),
+        ([-1, 0, 0], [1, 0, 0], [1, 2, 3], np.pi),
+        ([3, 0, 0], [0, 2, 0], [0, 0, -4], -np.pi / 2),
+        ([3, 0, 0], [0, 2, 0], [0, 0, 5], np.pi / 2),
+        ([-4, 0, 0], [1, 1, 0], [0, 0, 2], -3 * np.pi / 4),
+        (np.ones(4), np.ones(4), np.ones(4), None),
+    ],
+)
+def test_angle_signed_3d(array_u, array_v, positive_direction, angle_expected):
+
+    if not all(
+        [Vector(array_u).dimension == 3, Vector(array_v).dimension == 3, Vector(positive_direction).dimension == 3]
+    ):
+        with pytest.raises(ValueError, match="The vectors must be 3D."):
+            Vector(array_u).angle_signed_3d(array_v, positive_direction)
+
+    elif angle_expected is None:
+        with pytest.raises(
+            ValueError,
+            match="The positive direction vector must be perpendicular to the plane formed by the two input vectors."
+        ):
+            Vector(array_u).angle_signed_3d(array_v, positive_direction)
+
+    else:
+        angle = Vector(array_u).angle_signed_3d(array_v, positive_direction)
+        assert math.isclose(angle, angle_expected)
 
 @pytest.mark.parametrize(
     ("array_u", "array_v", "bool_expected"),

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -114,39 +114,31 @@ def test_angle_between(array_u, array_v, angle_expected):
 
 
 @pytest.mark.parametrize(
-    ("array_u", "array_v", "positive_direction", "angle_expected"),
+    ("array_u", "array_v", "angle_expected"),
     [
-        ([1, 0], [1, 0], None, 0),
-        ([1, 0], [1, 1], [1, 1], np.pi / 4),
-        ([1, 0], [1, 1], [1, 1, 0], np.pi / 4),
-        ([1, 0], [1, 1], None, np.pi / 4),
-        ([1, 0], [1, -1], None, -np.pi / 4),
-        ([1, 0], [0, 1], None, np.pi / 2),
-        ([1, 0], [-1, 1], None, 3 * np.pi / 4),
-        ([1, 0], [-1, 0], None, np.pi),
-        ([1, 0], [-1, -1], None, -3 * np.pi / 4),
-        ([1, 0], [0, -1], None, -np.pi / 2),
-        ([1, 0], [1, -1], None, -np.pi / 4),
-        ([1, 1], [0, 1], None, np.pi / 4),
-        ([1, 1], [1, 0], None, -np.pi / 4),
-        ([1, 0, 0], [0, 1, 0], None, np.pi / 2),
-        ([3, 0, 0], [0, 2, 0], [0, 1, 1], None),
-        ([3, 0, 0], [0, 2, 0], [0, 0, -4], -np.pi / 2),
-        ([3, 0, 0], [0, 2, 0], [0, 0, 5], np.pi / 2),
-        ([3, 0, 0], [0, 2, 0], None, np.pi / 2),
+        ([1, 0], [1, 0], 0),
+        ([1, 0], [1, 1], np.pi / 4),
+        ([1, 0], [0, 1], np.pi / 2),
+        ([1, 0], [-1, 1], 3 * np.pi / 4),
+        ([1, 0], [-1, 0], np.pi),
+        ([1, 0], [-1, -1], -3 * np.pi / 4),
+        ([1, 0], [0, -1], -np.pi / 2),
+        ([1, 0], [1, -1], -np.pi / 4),
+        ([1, 1], [0, 1], np.pi / 4),
+        ([1, 1], [1, 0], -np.pi / 4),
+        ([0], [0], None),
+        ([1, 1, 1], [1, 0, 0], None),
+        (np.ones(4), np.ones(4), None),
     ],
 )
-def test_angle_signed(array_u, array_v, positive_direction, angle_expected):
+def test_angle_signed(array_u, array_v, angle_expected):
 
-    if Vector(array_u).dimension == 3 and angle_expected is None:
-        with pytest.raises(
-            ValueError,
-            match="The positive direction vector must be perpendicular to the plane formed by the two input vectors."
-        ):
-            Vector(array_u).angle_signed(array_v, positive_direction)
+    if angle_expected is None:
+        with pytest.raises(ValueError, match="The vectors must be 2D."):
+            Vector(array_u).angle_signed(array_v)
 
     else:
-        angle = Vector(array_u).angle_signed(array_v, positive_direction)
+        angle = Vector(array_u).angle_signed(array_v)
         assert math.isclose(angle, angle_expected)
 
 

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -182,7 +182,7 @@ def test_angle_signed_3d(array_u, array_v, direction_positive, angle_expected):
             [3, 0, 0],
             [0, 2, 0],
             [0, 1, 1],
-            "The positive direction vector must be perpendicular to the plane formed by " "the two main input vectors.",
+            "The positive direction vector must be perpendicular to the plane formed by the two main input vectors.",
         ),
     ],
 )

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -142,7 +142,7 @@ def test_angle_signed(array_u, array_v, angle_expected):
         assert math.isclose(angle, angle_expected)
 
 @pytest.mark.parametrize(
-    ("array_u", "array_v", "positive_direction", "angle_expected"),
+    ("array_u", "array_v", "direction_positive", "angle_expected"),
     [
         ([1, 0], [1, 0], [0, 0, 3], None),
         ([3, 0, 0], [0, 2, 0], [0, 1, 1], None),
@@ -156,23 +156,23 @@ def test_angle_signed(array_u, array_v, angle_expected):
         (np.ones(4), np.ones(4), np.ones(4), None),
     ],
 )
-def test_angle_signed_3d(array_u, array_v, positive_direction, angle_expected):
+def test_angle_signed_3d(array_u, array_v, direction_positive, angle_expected):
 
     if not all(
-        [Vector(array_u).dimension == 3, Vector(array_v).dimension == 3, Vector(positive_direction).dimension == 3]
+        [Vector(array_u).dimension == 3, Vector(array_v).dimension == 3, Vector(direction_positive).dimension == 3]
     ):
         with pytest.raises(ValueError, match="The vectors must be 3D."):
-            Vector(array_u).angle_signed_3d(array_v, positive_direction)
+            Vector(array_u).angle_signed_3d(array_v, direction_positive)
 
     elif angle_expected is None:
         with pytest.raises(
             ValueError,
             match="The positive direction vector must be perpendicular to the plane formed by the two input vectors."
         ):
-            Vector(array_u).angle_signed_3d(array_v, positive_direction)
+            Vector(array_u).angle_signed_3d(array_v, direction_positive)
 
     else:
-        angle = Vector(array_u).angle_signed_3d(array_v, positive_direction)
+        angle = Vector(array_u).angle_signed_3d(array_v, direction_positive)
         assert math.isclose(angle, angle_expected)
 
 @pytest.mark.parametrize(

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -114,31 +114,39 @@ def test_angle_between(array_u, array_v, angle_expected):
 
 
 @pytest.mark.parametrize(
-    ("array_u", "array_v", "angle_expected"),
+    ("array_u", "array_v", "positive_direction", "angle_expected"),
     [
-        ([1, 0], [1, 0], 0),
-        ([1, 0], [1, 1], np.pi / 4),
-        ([1, 0], [0, 1], np.pi / 2),
-        ([1, 0], [-1, 1], 3 * np.pi / 4),
-        ([1, 0], [-1, 0], np.pi),
-        ([1, 0], [-1, -1], -3 * np.pi / 4),
-        ([1, 0], [0, -1], -np.pi / 2),
-        ([1, 0], [1, -1], -np.pi / 4),
-        ([1, 1], [0, 1], np.pi / 4),
-        ([1, 1], [1, 0], -np.pi / 4),
-        ([0], [0], None),
-        ([1, 1, 1], [1, 0, 0], None),
-        (np.ones(4), np.ones(4), None),
+        ([1, 0], [1, 0], None, 0),
+        ([1, 0], [1, 1], [1, 1], np.pi / 4),
+        ([1, 0], [1, 1], [1, 1, 0], np.pi / 4),
+        ([1, 0], [1, 1], None, np.pi / 4),
+        ([1, 0], [1, -1], None, -np.pi / 4),
+        ([1, 0], [0, 1], None, np.pi / 2),
+        ([1, 0], [-1, 1], None, 3 * np.pi / 4),
+        ([1, 0], [-1, 0], None, np.pi),
+        ([1, 0], [-1, -1], None, -3 * np.pi / 4),
+        ([1, 0], [0, -1], None, -np.pi / 2),
+        ([1, 0], [1, -1], None, -np.pi / 4),
+        ([1, 1], [0, 1], None, np.pi / 4),
+        ([1, 1], [1, 0], None, -np.pi / 4),
+        ([1, 0, 0], [0, 1, 0], None, np.pi / 2),
+        ([3, 0, 0], [0, 2, 0], [0, 1, 1], None),
+        ([3, 0, 0], [0, 2, 0], [0, 0, -4], -np.pi / 2),
+        ([3, 0, 0], [0, 2, 0], [0, 0, 5], np.pi / 2),
+        ([3, 0, 0], [0, 2, 0], None, np.pi / 2),
     ],
 )
-def test_angle_signed(array_u, array_v, angle_expected):
+def test_angle_signed(array_u, array_v, positive_direction, angle_expected):
 
-    if angle_expected is None:
-        with pytest.raises(ValueError, match="The vectors must be 2D."):
-            Vector(array_u).angle_signed(array_v)
+    if Vector(array_u).dimension == 3 and angle_expected is None:
+        with pytest.raises(
+            ValueError,
+            match="The positive direction vector must be perpendicular to the plane formed by the two input vectors."
+        ):
+            Vector(array_u).angle_signed(array_v, positive_direction)
 
     else:
-        angle = Vector(array_u).angle_signed(array_v)
+        angle = Vector(array_u).angle_signed(array_v, positive_direction)
         assert math.isclose(angle, angle_expected)
 
 

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -141,39 +141,39 @@ def test_angle_signed(array_u, array_v, angle_expected):
         angle = Vector(array_u).angle_signed(array_v)
         assert math.isclose(angle, angle_expected)
 
+
 @pytest.mark.parametrize(
     ("array_u", "array_v", "direction_positive", "angle_expected"),
     [
-        ([1, 0], [1, 0], [0, 0, 3], None),
-        ([3, 0, 0], [0, 2, 0], [0, 1, 1], None),
-        ([2, -1, 0], [0, 2, 0], [1, 1], None),
         ([1, 0, 0], [1, 0, 0], [1, 2, 3], 0),
         ([1, 0, 0], [-1, 0, 0], [1, 2, 3], np.pi),
         ([-1, 0, 0], [1, 0, 0], [1, 2, 3], np.pi),
         ([3, 0, 0], [0, 2, 0], [0, 0, -4], -np.pi / 2),
         ([3, 0, 0], [0, 2, 0], [0, 0, 5], np.pi / 2),
         ([-4, 0, 0], [1, 1, 0], [0, 0, 2], -3 * np.pi / 4),
-        (np.ones(4), np.ones(4), np.ones(4), None),
     ],
 )
 def test_angle_signed_3d(array_u, array_v, direction_positive, angle_expected):
 
-    if not all(
-        [Vector(array_u).dimension == 3, Vector(array_v).dimension == 3, Vector(direction_positive).dimension == 3]
-    ):
-        with pytest.raises(ValueError, match="The vectors must be 3D."):
-            Vector(array_u).angle_signed_3d(array_v, direction_positive)
+    angle = Vector(array_u).angle_signed_3d(array_v, direction_positive)
+    assert math.isclose(angle, angle_expected)
 
-    elif angle_expected is None:
-        with pytest.raises(
-            ValueError,
-            match="The positive direction vector must be perpendicular to the plane formed by the two input vectors."
-        ):
-            Vector(array_u).angle_signed_3d(array_v, direction_positive)
 
-    else:
-        angle = Vector(array_u).angle_signed_3d(array_v, direction_positive)
-        assert math.isclose(angle, angle_expected)
+@pytest.mark.parametrize(
+    ("array_u", "array_v", "direction_positive", "message_expected"),
+    [
+        ([1, 0], [1, 0], [0, 0, 3], "The vectors must be 3D."),
+        ([2, -1, 0], [0, 2, 0], [1, 1], "The vectors must be 3D."),
+        (np.ones(4), np.ones(4), np.ones(4), "The vectors must be 3D."),
+        ([3, 0, 0], [0, 2, 0], [0, 1, 1], "The positive direction vector must be perpendicular to the plane formed by "
+                                          "the two main input vectors."),
+    ],
+)
+def test_angle_signed_3d_failure(array_u, array_v, direction_positive, message_expected):
+
+    with pytest.raises(ValueError, match=message_expected):
+        Vector(array_u).angle_signed_3d(array_v, direction_positive)
+
 
 @pytest.mark.parametrize(
     ("array_u", "array_v", "bool_expected"),

--- a/tests/unit/objects/test_vector.py
+++ b/tests/unit/objects/test_vector.py
@@ -178,8 +178,12 @@ def test_angle_signed_3d(array_u, array_v, direction_positive, angle_expected):
         ([1, 0], [1, 0], [0, 0, 3], "The vectors must be 3D."),
         ([2, -1, 0], [0, 2, 0], [1, 1], "The vectors must be 3D."),
         (np.ones(4), np.ones(4), np.ones(4), "The vectors must be 3D."),
-        ([3, 0, 0], [0, 2, 0], [0, 1, 1], "The positive direction vector must be perpendicular to the plane formed by "
-                                          "the two main input vectors."),
+        (
+            [3, 0, 0],
+            [0, 2, 0],
+            [0, 1, 1],
+            "The positive direction vector must be perpendicular to the plane formed by " "the two main input vectors.",
+        ),
     ],
 )
 def test_angle_signed_3d_failure(array_u, array_v, direction_positive, message_expected):


### PR DESCRIPTION
Modify the `angle_signed` method of the `Vector` object to support 3D vectors and update unit tests.

The implemented logic is described [here](https://github.com/ajhynes7/scikit-spatial/issues/314).

**Issue**: the `np_float` decorator should be modify to actually use the `positive_direction` parameter as a keyword one. Currently, in the examples within the docstring, it's treated as a positional one. I don't know what's the best way to handle this. Can you give me some advice, please? Thanks!
The error is the following one:
`TypeError: wrapper() got an unexpected keyword argument 'positive_direction'`

